### PR TITLE
Add option to only show unmatched InstanceTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Audits your reserved EC2 instances against your currently running ones.
 
 ![reserved-instance-audit](doc/screenshots/reserved-instance-audit.png)
 
+Options:
+
+* `--only-unmatched`: Show only instance types that are not perfectly reserved.
+
 ### reserved-rds-audit
 
 Audits your reserved RDS instances against your currently running ones.

--- a/cmd/reserved-instance-audit/main.go
+++ b/cmd/reserved-instance-audit/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/jonstacks/aws/pkg/models"
@@ -9,6 +11,12 @@ import (
 )
 
 func main() {
+
+	onlyUnmatched := flag.Bool("only-unmatched", false,
+		"Only show instance types that are unmatched in running & reserved instnace count.")
+
+	flag.Parse()
+
 	s := session.Must(
 		session.NewSessionWithOptions(
 			session.Options{
@@ -26,6 +34,9 @@ func main() {
 	opts := models.RunningInstancesOpts{IncludeSpot: false}
 	all := models.RunningInstances(opts)
 
-	v := views.NewReservationUtilization(all, ris)
+	viewOpts := views.ReservationUtilizationOptions{
+		OnlyUnmatched: *onlyUnmatched,
+	}
+	v := views.NewReservationUtilization(all, ris, viewOpts)
 	v.Print()
 }


### PR DESCRIPTION
Ability to only show instance types that are either under or over reserved. Basically filter out instance types that have the same number running as are reserved.