### PR TITLE
Rds snapshot audit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: go
+
+go:
+  - "1.9.x"
+  - "1.10.x"
+
+install:
+  - go get -u github.com/golang/dep/...
+  - dep ensure
+
+# Don't email me the results of the test runs.
+notifications:
+  email: false
+
+script:
+- go test -v -race $(go list ./... | grep -v /vendor/)  # Run all the tests with the race detector enabled
+- go build ./cmd/...

--- a/cmd/rds-snapshot-audit/main.go
+++ b/cmd/rds-snapshot-audit/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/jonstacks/aws/pkg/models"
+	"github.com/jonstacks/aws/pkg/utils"
+	"github.com/jonstacks/aws/pkg/views"
+)
+
+func main() {
+	s := session.Must(
+		session.NewSessionWithOptions(
+			session.Options{
+				SharedConfigState: session.SharedConfigEnable,
+			},
+		),
+	)
+
+	client := rds.New(s)
+	models.RDSClient(client)
+
+	dbs, err := models.RunningDBInstances()
+	utils.ExitErrorHandler(err)
+
+	snapshots := models.DBSnapshots()
+
+	view := views.NewRDSSnapshotAudit(snapshots, dbs)
+
+	fmt.Printf("Number of Running DBs: %d\n", view.NumRunningInstances())
+	fmt.Printf("Number of DB Snapshots: %d\n", view.NumSnapshots())
+	fmt.Printf("Total Running storage: %d GB\n", view.TotalRunningStorageGB())
+	fmt.Printf("Total Virtual Snapshot storage: %d GB\n", view.TotalVirtualSnapshotStorageGB())
+
+	view.Render(os.Stdout)
+}

--- a/pkg/models/rds.go
+++ b/pkg/models/rds.go
@@ -35,9 +35,23 @@ func RunningDBInstances() ([]*rds.DBInstance, error) {
 	instances := resp.DBInstances
 	filtered := make([]*rds.DBInstance, 0)
 	for _, i := range instances {
-		if aws.StringValue(i.DBInstanceStatus) == "available" {
+		status := aws.StringValue(i.DBInstanceStatus)
+		if status == "available" || status == "backing-up" {
 			filtered = append(filtered, i)
 		}
 	}
 	return filtered, err
+}
+
+// DBSnapshots returns a slice of RDS Snapshots.
+func DBSnapshots() []*rds.DBSnapshot {
+	snapshots := make([]*rds.DBSnapshot, 0)
+	params := &rds.DescribeDBSnapshotsInput{}
+
+	rdsClient.DescribeDBSnapshotsPages(params,
+		func(page *rds.DescribeDBSnapshotsOutput, lastPage bool) bool {
+			snapshots = append(snapshots, page.DBSnapshots...)
+			return !lastPage
+		})
+	return snapshots
 }


### PR DESCRIPTION
Easily audit old snapshots that don't belong to a running RDS instance. This potentially save one lots of money on `RDS:ChargedBackupUsage`.
