### PR TITLE
Add command for getting spot instance request IPs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - "1.11.x"
   - "1.12.x"
+  - "1.13.x"
 
 # Don't email me the results of the test runs.
 notifications:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ AWS golang pkg, binaries, utils, etc.
 - [Auditing RDS Snapshots](#auditing-rds-snapshots)
 - [Finding available subnet space in a VPC](#finding-available-subnet-space-in-a-vpc)
 - [Getting a download URL for your RDS logs](#getting-a-download-url-for-your-rds-logs)
+- [Getting the IP of an EC2 Instance from the Spot Instance Request ID](#getting-the-ip-of-an-ec2-instance-from-the-spot-instance-request-id)
 
 <!-- /TOC -->
 
@@ -120,3 +121,19 @@ curl -sf -o $(basename $LOG_NAME) $LOG_URL
 
 *Note*: I have only really tested this against the `us-west-2` region. It might
         need some additional changes to support others use cases.
+
+## Getting the IP of an EC2 Instance from the Spot Instance Request ID
+
+To easily get the internal IP address of an instance given the spot
+instance request id, you can run the following:
+
+```
+spot-instance-ip sir-kd4rbkim sir-cmd8atam ...
+```
+
+And the output:
+
+```
+10.1.132.15
+10.1.136.232
+```

--- a/cmd/spot-instance-ip/main.go
+++ b/cmd/spot-instance-ip/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/jonstacks/aws/pkg/models"
+	"github.com/jonstacks/aws/pkg/utils"
+)
+
+func main() {
+	spotInstaceRequestIDs := os.Args[1:]
+
+	models.Init(models.DefaultSession())
+
+	requests, err := models.SpotInstanceRequests(spotInstaceRequestIDs)
+	utils.ExitErrorHandler(err)
+
+	instanceIDs := make([]string, 0)
+
+	for _, request := range requests {
+		instanceIDs = append(instanceIDs, aws.StringValue(request.InstanceId))
+	}
+
+	instances, err := models.Instances(instanceIDs)
+	utils.ExitErrorHandler(err)
+
+	for _, i := range instances {
+		if i != nil && i.PrivateIpAddress != nil {
+			fmt.Println(aws.StringValue(i.PrivateIpAddress))
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,14 @@ go 1.12
 
 require (
 	github.com/aws/aws-sdk-go v1.12.26
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-ini/ini v1.30.3 // indirect
 	github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 // indirect
 	github.com/jonstacks/networktree v1.0.0
 	github.com/mattn/go-runewidth v0.0.2 // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20171203151007-65fec0d89a57
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 // indirect
 	gopkg.in/ini.v1 v1.46.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/aws/aws-sdk-go v1.12.26 h1:s/HsACT8nfmmgvy4UUNP7In/EQzu3NyIASbJj8hFF8
 github.com/aws/aws-sdk-go v1.12.26/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-ini/ini v1.30.3 h1:eJyRhmn24uq++Vv3zw+f1Ixd75RBsqsFnxzZCVrEQaU=
 github.com/go-ini/ini v1.30.3/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
@@ -22,8 +24,11 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykE
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 h1:WN9BUFbdyOsSH/XohnWpXOlq9NBD5sGAB2FciQMUEe8=
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 h1:Ao/3l156eZf2AW5wK8a7/smtodRU+gha3+BeqJ69lRk=

--- a/pkg/models/ec2.go
+++ b/pkg/models/ec2.go
@@ -12,6 +12,27 @@ func EC2Client(client *ec2.EC2) {
 	ec2Client = client
 }
 
+// Instances retrieves a list of instances by their instance IDs and returns
+// an error if one occured.
+func Instances(IDs []string) (instances []*ec2.Instance, err error) {
+	var resp *ec2.DescribeInstancesOutput
+
+	params := &ec2.DescribeInstancesInput{
+		InstanceIds: aws.StringSlice(IDs),
+	}
+	resp, err = ec2Client.DescribeInstances(params)
+	if err != nil {
+		return
+	}
+	instances = make([]*ec2.Instance, 0)
+	for _, r := range resp.Reservations {
+		for _, i := range r.Instances {
+			instances = append(instances, i)
+		}
+	}
+	return
+}
+
 // ReservedInstances returns a slice of reserved instances.
 func ReservedInstances() ([]*ec2.ReservedInstances, error) {
 	params := &ec2.DescribeReservedInstancesInput{
@@ -64,6 +85,19 @@ func RunningInstances(opts RunningInstancesOpts) []*ec2.Instance {
 		instances = filtered
 	}
 	return instances
+}
+
+// SpotInstanceRequests returns a slice of spot instance requests by their IDs
+// and an error if one occurs.
+func SpotInstanceRequests(requestIDs []string) (reqs []*ec2.SpotInstanceRequest, err error) {
+	var resp *ec2.DescribeSpotInstanceRequestsOutput
+
+	params := &ec2.DescribeSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: aws.StringSlice(requestIDs),
+	}
+	resp, err = ec2Client.DescribeSpotInstanceRequests(params)
+	reqs = resp.SpotInstanceRequests
+	return
 }
 
 // Subnets returns a list of subnets

--- a/pkg/models/ec2.go
+++ b/pkg/models/ec2.go
@@ -26,9 +26,7 @@ func Instances(IDs []string) (instances []*ec2.Instance, err error) {
 	}
 	instances = make([]*ec2.Instance, 0)
 	for _, r := range resp.Reservations {
-		for _, i := range r.Instances {
-			instances = append(instances, i)
-		}
+		instances = append(instances, r.Instances...)
 	}
 	return
 }

--- a/pkg/utils/ec2.go
+++ b/pkg/utils/ec2.go
@@ -13,12 +13,7 @@ import (
 // GetInstanceName returns the name for an ec2.Instance. If there is no
 // associated name tag, it returns an empty string.
 func GetInstanceName(i *ec2.Instance) string {
-	for _, t := range i.Tags {
-		if aws.StringValue(t.Key) == "Name" {
-			return aws.StringValue(t.Value)
-		}
-	}
-	return ""
+	return GetTagValue(i.Tags, "Name")
 }
 
 // ExitErrorHandler exits the program with a non-zero exit status if err != nil
@@ -69,4 +64,15 @@ func IsSubnetEmpty(subnet *ec2.Subnet) bool {
 	emptySubnetSize := int64(size - 5)
 
 	return aws.Int64Value(subnet.AvailableIpAddressCount) == emptySubnetSize
+}
+
+// StringSliceContains returns true if the slice contains the string, otherwise
+// false
+func StringSliceContains(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/utils/ec2_test.go
+++ b/pkg/utils/ec2_test.go
@@ -3,8 +3,41 @@ package utils
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/assert"
 )
+
+var testInstance1 = &ec2.Instance{
+	Tags: []*ec2.Tag{
+		&ec2.Tag{
+			Key:   aws.String("Name"),
+			Value: aws.String("my-test-instance"),
+		},
+	},
+}
+
+var testInstance2 = &ec2.Instance{
+	Tags: []*ec2.Tag{
+		&ec2.Tag{
+			Key:   aws.String("Expires"),
+			Value: aws.String("2012-03-20"),
+		},
+	},
+}
+
+func TestGetInstanceName(t *testing.T) {
+	assert.Equal(t, "my-test-instance", GetInstanceName(testInstance1))
+	assert.Equal(t, "", GetInstanceName(testInstance2))
+}
+
+func TestGetTagValue(t *testing.T) {
+	assert.Equal(t, "my-test-instance", GetTagValue(testInstance1.Tags, "Name"))
+	assert.Equal(t, "", GetTagValue(testInstance1.Tags, "MissingTag"))
+
+	assert.Equal(t, "", GetTagValue(testInstance2.Tags, "Name"))
+	assert.Equal(t, "2012-03-20", GetTagValue(testInstance2.Tags, "Expires"))
+}
 
 func TestSubnetSize(t *testing.T) {
 	size, err := SubnetSize("10.1.0.0/24")
@@ -22,4 +55,23 @@ func TestSubnetSize(t *testing.T) {
 	size, err = SubnetSize("10.1.0.0/32")
 	assert.Nil(t, err)
 	assert.Equal(t, 1, size)
+}
+
+func TestStringSliceContains(t *testing.T) {
+	testCases := []struct {
+		slice          []string
+		searchTerm     string
+		expectedResult bool
+	}{
+		{[]string{"a", "b", "c", "d"}, "c", true},
+		{[]string{"a", "b", "c", "d"}, "a", true},
+		{[]string{}, "a", false},
+		{[]string{}, "", false},
+		{[]string{""}, "c", false},
+		{[]string{"a", "b"}, "c", false},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedResult, StringSliceContains(tc.slice, tc.searchTerm))
+	}
 }


### PR DESCRIPTION
This command makes it easy to get the instance's private IPs from just the spot instance request ID