### PR TITLE
Update the normalized units

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        go-version: [1.12, 1.13, 1.14, 1.15]
+        go-version: [1.15, 1.16, 1.17, 1.18]
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.13
+        go-version: ${{ matrix.go-version }}
     - run: go build ./cmd/...

--- a/pkg/views/common.go
+++ b/pkg/views/common.go
@@ -4,8 +4,8 @@ package views
 // Instance type are running
 type InstanceTypeReservationUtilization struct {
 	InstanceType string
-	NumReserved  int
-	NumRunning   int
+	NumReserved  float64
+	NumRunning   float64
 }
 
 func (i *InstanceTypeReservationUtilization) String() string {
@@ -21,6 +21,6 @@ func (i *InstanceTypeReservationUtilization) HasUnused() bool {
 // Unreserved returns the difference between the number of running instances
 // and the number of reserved instances. A negative result implies there are
 // more instances reserved than running.
-func (i *InstanceTypeReservationUtilization) Unreserved() int {
+func (i *InstanceTypeReservationUtilization) Unreserved() float64 {
 	return i.NumRunning - i.NumReserved
 }

--- a/pkg/views/ec2.go
+++ b/pkg/views/ec2.go
@@ -50,7 +50,7 @@ func NewReservationUtilization(running []*ec2.Instance, reservations []*ec2.Rese
 	for _, r := range ru.Reservations {
 		itype := aws.StringValue(r.InstanceType)
 		iru := ru.getOrInitializeITypeReservation(itype)
-		iru.NumReserved += int(*r.InstanceCount)
+		iru.NumReserved += float64(*r.InstanceCount)
 	}
 
 	if opts.OnlyUnmatched {
@@ -109,10 +109,10 @@ func (ru *ReservationUtilization) Print() {
 		}
 		table.Append([]string{
 			k,
-			strconv.Itoa(iru.NumRunning),
-			strconv.Itoa(iru.NumReserved),
+			fmt.Sprintf("%.2f", iru.NumRunning),
+			fmt.Sprintf("%.2f", iru.NumReserved),
 			extra,
-			strconv.Itoa(iru.Unreserved()),
+			fmt.Sprintf("%.2f", iru.Unreserved()),
 		})
 	}
 

--- a/pkg/views/rds_test.go
+++ b/pkg/views/rds_test.go
@@ -3,8 +3,28 @@ package views
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/stretchr/testify/assert"
 )
+
+func makeRDSInstance(instanceIdentifier, instanceType, engine string, multiAZ bool) *rds.DBInstance {
+	return &rds.DBInstance{
+		DBInstanceIdentifier: aws.String(instanceIdentifier),
+		DBInstanceClass:      aws.String(instanceType),
+		Engine:               aws.String(engine),
+		MultiAZ:              aws.Bool(multiAZ),
+	}
+}
+
+func makeRDSReservation(instanceType, productDescription string, count int) *rds.ReservedDBInstance {
+	return &rds.ReservedDBInstance{
+		DBInstanceClass:    aws.String(instanceType),
+		DBInstanceCount:    aws.Int64(int64(count)),
+		ProductDescription: aws.String(productDescription),
+		State:              aws.String("active"),
+	}
+}
 
 func TestGetInstanceFamily(t *testing.T) {
 	x := rdsInstanceType("db.m5.large")
@@ -12,5 +32,37 @@ func TestGetInstanceFamily(t *testing.T) {
 	assert.Equal(t, "large", x.size())
 	units, ok := x.normalizedUnits()
 	assert.True(t, ok)
-	assert.Equal(t, 8, units)
+	assert.Equal(t, 4.0, units)
+}
+
+func TestRDSResrvationUtilization(t *testing.T) {
+	utilization := NewRDSReservationUtilization(
+		[]*rds.DBInstance{
+			makeRDSInstance("db-1", "db.m5.large", "postgresql", true),
+			makeRDSInstance("db-2", "db.m5.large", "postgresql", false),
+			makeRDSInstance("db-3", "db.m5.large", "postgresql", false),
+			makeRDSInstance("db-4", "db.m5.large", "aurora-postgresql", true),
+		},
+		[]*rds.ReservedDBInstance{
+			makeRDSReservation("db.m5.large", "postgresql", 3),
+			makeRDSReservation("db.r6.2xlarge", "aurora-postgresql", 2),
+		},
+	)
+
+	// Should have 16 running units. 2 normal larges = 2 * 4 = 8. And 1 MultiAZ large = 2 * 4 = 8, so 16 units total.
+	assert.Equal(t, 16.0, utilization.InstanceTypeReservationUtilizations["postgresql/db.m5"].NumRunning)
+	assert.Equal(t, 12.0, utilization.InstanceTypeReservationUtilizations["postgresql/db.m5"].NumReserved)
+	assert.Equal(t, 4.0, utilization.InstanceTypeReservationUtilizations["postgresql/db.m5"].Unreserved())
+	assert.Equal(t, false, utilization.InstanceTypeReservationUtilizations["postgresql/db.m5"].HasUnused())
+
+	// Again, here we expect 8 normalized units, 4 for each large since its MultiAZ.
+	assert.Equal(t, 8.0, utilization.InstanceTypeReservationUtilizations["aurora-postgresql/db.m5"].NumRunning)
+	assert.Equal(t, 0.0, utilization.InstanceTypeReservationUtilizations["aurora-postgresql/db.m5"].NumReserved)
+	assert.Equal(t, 8.0, utilization.InstanceTypeReservationUtilizations["aurora-postgresql/db.m5"].Unreserved())
+	assert.Equal(t, false, utilization.InstanceTypeReservationUtilizations["aurora-postgresql/db.m5"].HasUnused())
+
+	assert.Equal(t, 0.0, utilization.InstanceTypeReservationUtilizations["aurora-postgresql/db.r6"].NumRunning)
+	assert.Equal(t, 32.0, utilization.InstanceTypeReservationUtilizations["aurora-postgresql/db.r6"].NumReserved)
+	assert.Equal(t, -32.0, utilization.InstanceTypeReservationUtilizations["aurora-postgresql/db.r6"].Unreserved())
+	assert.Equal(t, true, utilization.InstanceTypeReservationUtilizations["aurora-postgresql/db.r6"].HasUnused())
 }


### PR DESCRIPTION
Update the normalized units to match the AWS documentation so `reserved-rds-audit` is easier to use. 